### PR TITLE
[hotfix] npm build output dir 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.config/
-
+*config/
+*log/

--- a/Front_end/vue.config.js
+++ b/Front_end/vue.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = {
     publicPath: '/static/src/vue/dist/', // Should be STATIC_URL + path/to/build
-    outputDir: path.resolve(__dirname, '../static/src/vue/dist/'), // Output to a directory in STATICFILES_DIRS
+    outputDir: path.resolve(__dirname, '../Back_end/static/src/vue/dist/'), // Output to a directory in STATICFILES_DIRS
     filenameHashing: false, // Django will hash file names, not webpack
     runtimeCompiler: true, // See: https://vuejs.org/v2/guide/installation.html#Runtime-Compiler-vs-Runtime-only
     devServer: {


### PR DESCRIPTION
프로젝트 디렉토리 구조 변경으로 인해
npm build 경로를 재설정해주었습니다.
저렇게 해야 기존 vue 컴포넌트 사용가능합니다.