### PR TITLE
[bugfix/#121] 자기소개 작성 후 재 변경시 공백 앞에 있는 것 수정

### DIFF
--- a/Back_end/my_info/templates/my_info.html
+++ b/Back_end/my_info/templates/my_info.html
@@ -1190,8 +1190,7 @@
                                                 <!--설명 내용 수정 부분-->
                                                 <textarea name="user_intro" required="required"
                                                           class="form-control"
-                                                          placeholder="간단한 본인 소개를 적어주세요">{% if logined_user.user_intro %}
-                                                    {{ logined_user.user_intro }}{% endif %}</textarea>
+                                                          placeholder="간단한 본인 소개를 적어주세요">{% if logined_user.user_intro %}{{ logined_user.user_intro }}{% endif %}</textarea>
                                             </div>
                                             <!--수정신청하기 버튼, Back : 누르면 회장에게 승인을 요구하도록 수정-->
                                             <a href="#" class="site-button"


### PR DESCRIPTION
template tag는 문서 포매팅 상관 없이 탭, 빈문자열 등이 앞에 있어선 안됨.  따라서 그냥 공백을 없앴음.