### PR TITLE
[bugfix/#125] 윈도우 설치환경 충돌 해결

### DIFF
--- a/Back_end/requirements-local.txt
+++ b/Back_end/requirements-local.txt
@@ -15,9 +15,9 @@ django-summernote==0.8.11.6
 django-widget-tweaks==1.4.8
 djangorestframework==3.12.4
 idna==2.10
-mysqlclient==2.0.3
+mysqlclient==2.1.0
 oauthlib==3.1.0
-Pillow==8.1.0
+Pillow==8.4.0
 pycparser==2.20
 PyJWT==2.0.1
 python3-openid==3.2.0


### PR DESCRIPTION
related to: #125 

윈도우 환경에서 requirements.txt 로 의존성 설치 하는 중에 pillow, mysqlclient 버전 충돌이 생겨서 버전을 수정했습니다.
리눅스 환경 혹은 맥 환경에서 잘 실행되는지 확인이 필요합니다.